### PR TITLE
fix 'openssl s_client' cannot connect to cntls server

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1943,22 +1943,22 @@ int s_client_main(int argc, char **argv)
         goto end;
 
 #ifndef OPENSSL_NO_CNSM
-    if (cnsm_flag && SSL_CTX_use_certificate_file(ctx, key_enc_file, SSL_FILETYPE_PEM) <= 0)
+    if (cnsm_flag && SSL_CTX_use_enc_certificate_file(ctx, cert_enc_file, SSL_FILETYPE_PEM) <= 0)
     {
-            ERR_print_errors(bio_err);
-            goto end;
+        ERR_print_errors(bio_err);
+        goto end;
     }
-    if (cnsm_flag && SSL_CTX_use_enc_PrivateKey_file(ctx, cert_enc_file, SSL_FILETYPE_PEM) <= 0)
+    if (cnsm_flag && SSL_CTX_use_enc_PrivateKey_file(ctx, key_enc_file, SSL_FILETYPE_PEM) <= 0)
     {
-            ERR_print_errors(bio_err);
-            goto end;
+        ERR_print_errors(bio_err);
+        goto end;
     }
 
-     if (cnsm_flag && !SSL_CTX_check_enc_private_key(ctx))
-     {
-             ERR_print_errors(bio_err);
-             goto end;
-     }
+    if (cnsm_flag && !SSL_CTX_check_enc_private_key(ctx))
+    {
+        ERR_print_errors(bio_err);
+        goto end;
+    }
 #endif
 
     if (!noservername) {


### PR DESCRIPTION
`./openssl s_client -connect xxxx:xx -cert ../tassl_demo/cert/certs/CS.pem -cert_enc ../tassl_demo/cert/certs/CE.pem` 使用国密连接的时候无法正常使用国密协议，原因是`SSL_CTX_use_enc_certificate_file`被写成了`SSL_CTX_use_certificate_file`，另外`key_enc_file`和`cert_enc_file`有误，已经调换