### PR TITLE
fix Makefile install issue on macOS Big Sur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ install_tass:
         PWD2=`cd ${INSTALLTOP}/../tassl; pwd`;\
         if [ "$$PWD1" != "$$PWD2" ]; then rm -rf $(INSTALLTOP)/../tassl; ln -fs $(INSTALLTOP) $(INSTALLTOP)/../tassl; fi;
 	rm -rf $(GEN_SM2_CERT_FILE).sh
-	cp -R tassl_demo/ $(INSTALLTOP)/
+	cp -R tassl_demo $(INSTALLTOP)/
 	mv $(GEN_SM2_CERT_FILE).tmpl $(GEN_SM2_CERT_FILE).sh
 	mv $(SSL_MK_FILE).tmpl $(SSL_MK_FILE).sh
 	mv $(CRYPTO_MK_FILE).tmpl $(CRYPTO_MK_FILE).sh


### PR DESCRIPTION
复现过程：

```


$ uname -a
Darwin *.lan 20.1.0 Darwin Kernel Version 20.1.0: Sat Oct 31 00:07:11 PDT 2020; root:xnu-7195.50.7~2/RELEASE_X86_64 x86_64

$ tar xf TASSL-1.1.1b-V_1.4.tar.gz

$ make distclean

$ chmod +x config

$ ./config --prefix=`pwd`/.openssl

$ make -j4
/tmp/TASSL-1.1.1b-V_1.4/.openssl/share/doc/openssl/html/man7/X448.html -> /tmp/TASSL-1.1.1b-V_1.4/.openssl/share/doc/openssl/html/man7/X25519.html
/tmp/TASSL-1.1.1b-V_1.4/.openssl/share/doc/openssl/html/man7/x509.html
PWD1=`cd /tmp/TASSL-1.1.1b-V_1.4/.openssl; pwd`;\
        PWD2=`cd /tmp/TASSL-1.1.1b-V_1.4/.openssl/../tassl; pwd`;\
        if [ "$PWD1" != "$PWD2" ]; then rm -rf /tmp/TASSL-1.1.1b-V_1.4/.openssl/../tassl; ln -fs /tmp/TASSL-1.1.1b-V_1.4/.openssl /tmp/TASSL-1.1.1b-V_1.4/.openssl/../tassl; fi;
rm -rf /tmp/TASSL-1.1.1b-V_1.4/.openssl/tassl_demo/cert/gen_sm2_cert.sh
cp -R tassl_demo/ /tmp/TASSL-1.1.1b-V_1.4/.openssl/
mv /tmp/TASSL-1.1.1b-V_1.4/.openssl/tassl_demo/cert/gen_sm2_cert.tmpl /tmp/TASSL-1.1.1b-V_1.4/.openssl/tassl_demo/cert/gen_sm2_cert.sh
mv: rename /tmp/TASSL-1.1.1b-V_1.4/.openssl/tassl_demo/cert/gen_sm2_cert.tmpl to /tmp/TASSL-1.1.1b-V_1.4/.openssl/tassl_demo/cert/gen_sm2_cert.sh: No such file or directory
make: *** [install_tass] Error 1

```